### PR TITLE
Add endpoint to fetch video options, add thumbnail generation functionality

### DIFF
--- a/src/controllers/videoController.ts
+++ b/src/controllers/videoController.ts
@@ -1,33 +1,67 @@
 import * as fs from "fs";
+import path from "path";
+import { exec } from "child_process";
+import { promisify } from "util";
 import { Request, Response } from "express";
 import { db, storage } from "../config/firebase";
+import { auth } from "firebase-admin";
 
+// Type representing video options that can be shown to user.
+type VideoOption = {
+  title: string;
+  uploaderDisplayName: string;
+  uploaderPfp: string;
+  uploadDate: string;
+  views: number;
+  thumbnailSignedLink: string;
+};
+
+const execAsync = promisify(exec);
+
+/**
+ * Uploads a video and its thumbnail to Firebase Storage and adds metadata to Firestore.
+ * @param {Request} req Request object.
+ * @param {Response} res Response object.
+ */
 export async function uploadVideo(req: Request, res: Response) {
   let videoFile: Express.Multer.File | null = null;
   let thumbnailFile: Express.Multer.File | null = null;
+  let generatedThumbnailPath: string | null = null;
 
   try {
     // parse JSON data
-    const { title, description, uploaderUsername } = req.body;
-    if (!title || !uploaderUsername) {
+    const { title, description, uploader } = req.body;
+    if (!title || !uploader) {
       res.status(400).json({ error: "Missing required fields" });
       return;
     }
 
     // check files
     const files = req.files as { [fieldname: string]: Express.Multer.File[] };
-    if (!files.videoFile || !files.thumbnailFile) {
-      res.status(400).json({ error: "Missing required files" });
+    if (!files.videoFile) {
+      res.status(400).json({ error: "Missing required file" });
       return;
     }
     videoFile = files.videoFile[0];
-    thumbnailFile = files.thumbnailFile[0];
+    thumbnailFile = files.thumbnailFile ? files.thumbnailFile[0] : null;
+
+    // if no thumbnail file is provider, generate one
+    if (!thumbnailFile) {
+      const thumbnailPath = `thumbnail-${Date.now()}.jpg`;
+      generatedThumbnailPath = path.join("/tmp", thumbnailPath);
+      await execAsync(
+        `ffmpeg -i ${videoFile.path} -ss 00:00:01.000 -vframes 1 ${generatedThumbnailPath}`,
+      );
+      if (!fs.existsSync(generatedThumbnailPath)) {
+        throw new Error("Failed to generate thumbnail");
+      }
+    }
 
     // add document to video collection in Firestore, save ID
     const videoData = {
       title,
       description,
-      uploader: uploaderUsername,
+      uploader,
       views: 0,
       uploadDate: new Date().toISOString(),
     };
@@ -49,18 +83,22 @@ export async function uploadVideo(req: Request, res: Response) {
 
     // put thumbnail in Firebase storage bucket
     const thumbnailDestPath = `thumbnails/${videoId}`;
-    await bucket.upload(thumbnailFile.path, {
-      destination: thumbnailDestPath,
-      metadata: {
-        contentType: thumbnailFile.mimetype,
+    await bucket.upload(
+      thumbnailFile ? thumbnailFile.path : generatedThumbnailPath || "",
+      {
+        destination: thumbnailDestPath,
         metadata: {
-          originalFilename: thumbnailFile.originalname,
+          contentType: thumbnailFile ? thumbnailFile.mimetype : "image/jpeg",
+          metadata: {
+            originalFilename: thumbnailFile
+              ? thumbnailFile.originalname
+              : "generated-thumbnail.jpg",
+          },
         },
       },
-    });
+    );
 
     res.status(200).json({
-      message: "Video and thumbnail uploaded successfully",
       videoId,
     });
   } catch (error) {
@@ -72,5 +110,56 @@ export async function uploadVideo(req: Request, res: Response) {
   } finally {
     if (videoFile) fs.unlinkSync(videoFile.path);
     if (thumbnailFile) fs.unlinkSync(thumbnailFile.path);
+  }
+}
+
+/**
+ * Retrieves video options from Firestore and generates signed URLs for thumbnails.
+ * @param {Request} _req Request object.
+ * @param {Response} res Response object.
+ */
+export async function getVideoOptions(_req: Request, res: Response) {
+  try {
+    const videoCollection = db().collection("video");
+    const snapshot = await videoCollection.get();
+    const videoOptions: VideoOption[] = [];
+    snapshot.forEach(async (doc) => {
+      const data = doc.data();
+      const videoId = doc.id;
+
+      // get thumbnail signed link
+      const [thumbnailSignedLink] = await storage()
+        .bucket()
+        .file(`thumbnails/${videoId}`)
+        .getSignedUrl({
+          action: "read",
+          expires: Date.now() + 60 * 60 * 1000, // valid for 1 hour
+        });
+
+      // get uploader display name and pfp
+      const userRecord = await auth().getUser(data.uploader);
+      const uploaderDisplayName = userRecord.displayName;
+      const uploaderPfp = userRecord.photoURL;
+
+      // add to video options
+      videoOptions.push({
+        title: data.title,
+        uploaderDisplayName: uploaderDisplayName || "",
+        uploaderPfp: uploaderPfp || "",
+        uploadDate: data.uploadDate,
+        views: data.views,
+        thumbnailSignedLink,
+      });
+    });
+
+    res.status(200).json({
+      videoOptions: videoOptions,
+    });
+  } catch (error) {
+    console.error("Error fetching video options:", error);
+    res.status(500).json({
+      error: "Failed to fetch video options",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
   }
 }

--- a/src/controllers/videoController.ts
+++ b/src/controllers/videoController.ts
@@ -123,6 +123,8 @@ export async function uploadVideo(req: Request, res: Response) {
  * @param {Response} res Response object.
  */
 export async function getVideoOptions(_req: Request, res: Response) {
+  // TODO: Implement semi-random ordering for variety
+  // TODO: Implement pagination for large number of videos
   try {
     const videoCollection = db().collection("video");
     const snapshot = await videoCollection.get();

--- a/src/routes/videoRoutes.ts
+++ b/src/routes/videoRoutes.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import multer from "multer";
 import * as os from "os";
 import { authenticateUser } from "../middleware/authMiddleware";
-import { uploadVideo } from "../controllers/videoController";
+import { getVideoOptions, uploadVideo } from "../controllers/videoController";
 
 const videoRouter = Router();
 
@@ -17,5 +17,7 @@ videoRouter.post(
   ]),
   uploadVideo,
 );
+
+videoRouter.get("/", authenticateUser, getVideoOptions);
 
 export default videoRouter;


### PR DESCRIPTION
These changes add an endpoint to fetch video options from Firebase, paired with their thumbnail and details about the uploading user. Note that this endpoint should be expanded in the future to both allow for "random" ordering for discovery, as well as pagination to ease client-side load.

Additionally, thumbnail generation has been added to the upload endpoint, making it so that users do not have to attach their own thumbnail.