### PR TITLE
Add endpoints to view video and increment view count

### DIFF
--- a/src/controllers/videoController.ts
+++ b/src/controllers/videoController.ts
@@ -17,7 +17,32 @@ type VideoOption = {
   thumbnailSignedLink: string;
 };
 
+type VideoDetails = {
+  id: string;
+  title: string;
+  description: string;
+  uploaderDisplayName: string;
+  uploaderPfp: string;
+  uploadDate: string;
+  views: number;
+  videoSignedUrl: string;
+};
+
 const execAsync = promisify(exec);
+
+/**
+ * Helper function to fetch uploader details.
+ * @param {string} uploaderId ID of the uploading user.
+ * @returns { uploaderDisplayName: string; uploaderPfp: string } Display name and link to PFP.
+ */
+async function getUploaderDetails(
+  uploaderId: string,
+): Promise<{ uploaderDisplayName: string; uploaderPfp: string }> {
+  const userRecord = await auth().getUser(uploaderId);
+  const uploaderDisplayName = userRecord.displayName || "";
+  const uploaderPfp = userRecord.photoURL || "";
+  return { uploaderDisplayName, uploaderPfp };
+}
 
 /**
  * Uploads a video and its thumbnail to Firebase Storage and adds metadata to Firestore.
@@ -131,7 +156,7 @@ export async function getVideoOptions(_req: Request, res: Response) {
 
     const videoOptions: VideoOption[] = await Promise.all(
       snapshot.docs.map(async (doc) => {
-        const data = doc.data();
+        const videoData = doc.data();
         const videoId = doc.id;
 
         // get thumbnail signed link
@@ -144,17 +169,17 @@ export async function getVideoOptions(_req: Request, res: Response) {
           });
 
         // get uploader display name and pfp
-        const userRecord = await auth().getUser(data.uploader);
-        const uploaderDisplayName = userRecord.displayName;
-        const uploaderPfp = userRecord.photoURL;
+        const { uploaderDisplayName, uploaderPfp } = await getUploaderDetails(
+          videoData.uploader,
+        );
 
         return {
           id: videoId,
-          title: data.title,
+          title: videoData.title,
           uploaderDisplayName: uploaderDisplayName || "",
           uploaderPfp: uploaderPfp || "",
-          uploadDate: data.uploadDate,
-          views: data.views,
+          uploadDate: videoData.uploadDate,
+          views: videoData.views,
           thumbnailSignedLink,
         };
       }),
@@ -165,6 +190,66 @@ export async function getVideoOptions(_req: Request, res: Response) {
     });
   } catch (error) {
     console.error("Error fetching video options:", error);
+    res.status(500).json({
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+}
+
+/**
+ * Retrieves detailed information about a video, including a signed video URL and description.
+ * @param {Request} req Request object.
+ * @param {Response} res Response object.
+ */
+export async function getVideoDetails(req: Request, res: Response) {
+  const { videoId } = req.params;
+  if (!videoId) {
+    res.status(400).json({ error: "Missing video ID" });
+    return;
+  }
+
+  try {
+    // get video metadata
+    const videoDoc = await db().collection("video").doc(videoId).get();
+    if (!videoDoc.exists) {
+      res.status(404).json({ error: "Video not found" });
+      return;
+    }
+    const videoData = videoDoc.data();
+    if (!videoData) {
+      res.status(500).json({ error: "Failed to retrieve video data" });
+      return;
+    }
+
+    // get video signed link
+    const [videoSignedUrl] = await storage()
+      .bucket()
+      .file(`videos/${videoId}`)
+      .getSignedUrl({
+        action: "read",
+        expires: Date.now() + 60 * 60 * 1000, // valid for 1 hour
+      });
+
+    // get uploader display name and pfp
+    const { uploaderDisplayName, uploaderPfp } = await getUploaderDetails(
+      videoData.uploader,
+    );
+
+    // Construct response object
+    const videoDetails: VideoDetails = {
+      id: videoId,
+      title: videoData.title,
+      description: videoData.description,
+      uploaderDisplayName,
+      uploaderPfp,
+      uploadDate: videoData.uploadDate,
+      views: videoData.views,
+      videoSignedUrl,
+    };
+
+    res.status(200).json(videoDetails);
+  } catch (error) {
+    console.error("Error fetching video details:", error);
     res.status(500).json({
       error: error instanceof Error ? error.message : "Unknown error",
     });

--- a/src/routes/videoRoutes.ts
+++ b/src/routes/videoRoutes.ts
@@ -2,7 +2,11 @@ import { Router } from "express";
 import multer from "multer";
 import * as os from "os";
 import { authenticateUser } from "../middleware/authMiddleware";
-import { getVideoOptions, uploadVideo } from "../controllers/videoController";
+import {
+  getVideoDetails,
+  getVideoOptions,
+  uploadVideo,
+} from "../controllers/videoController";
 
 const videoRouter = Router();
 
@@ -17,7 +21,7 @@ videoRouter.post(
   ]),
   uploadVideo,
 );
-
 videoRouter.get("/", authenticateUser, getVideoOptions);
+videoRouter.get("/:videoId", authenticateUser, getVideoDetails);
 
 export default videoRouter;

--- a/src/routes/videoRoutes.ts
+++ b/src/routes/videoRoutes.ts
@@ -5,6 +5,7 @@ import { authenticateUser } from "../middleware/authMiddleware";
 import {
   getVideoDetails,
   getVideoOptions,
+  incrementViewCount,
   uploadVideo,
 } from "../controllers/videoController";
 
@@ -23,5 +24,6 @@ videoRouter.post(
 );
 videoRouter.get("/", authenticateUser, getVideoOptions);
 videoRouter.get("/:videoId", authenticateUser, getVideoDetails);
+videoRouter.post("/:videoId/view", authenticateUser, incrementViewCount);
 
 export default videoRouter;


### PR DESCRIPTION
These changes add two endpoints. One gets details for a video with a given ID, including a signed link to view it, The second increments the view count for a video with a given ID.